### PR TITLE
Resolves #1294, corrects issue with Resources on multi-language course

### DIFF
--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -38,9 +38,5 @@ define([
 
     }
 
-    Adapt.once('app:dataReady', function() {
-        initResources();
-        Adapt.on('app:languageChanged', initResources);
-    });
-
+    Adapt.on('app:dataReady', initResources);
 });


### PR DESCRIPTION
The binding for 'app:dataReady' has changed from .once() to .on().  The course data is only ready when 'app:dataReady' is triggered.