### PR TITLE
Feature/file rename on download (issue #1377)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ The attributes listed below are used in *course.json* to configure **Resources**
 
 >>**description** (string):  This optional text appears (along with **title**) as a label on the button that links to the item.    
 
+>>**filename** (string): This can be used to set the name of the file when downloaded by the user, if different from the source filename. (This feature is not supported on IE8-IE11, or Safari 10.)
+
 >>**_link** (string):  This value is the URI that accesses the resource item, e.g., *course/en/pdf/diagram.pdf*.
 
 <div float align=right><a href="#top">Back to Top</a></div>

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-resources",
-  "version": "2.1.0",
+  "version": "2.0.6",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-resources",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-resources%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-resources",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-resources",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-resources%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/example.json
+++ b/example.json
@@ -22,6 +22,7 @@
             "_type":"document",
             "title":"Button idea",
             "description":"Click here to see a proposed button idea",
+            "filename":"Buttons.pdf",
             "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf"
         },
         {

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -52,7 +52,7 @@ define(function(require) {
             var data = $(event.currentTarget).data();
 
             if ('document' !== data.type) {
-              window.top.open($(event.currentTarget).data("href"), 'MyFile.jpg');
+              window.top.open($(event.currentTarget).data("href"));
               return;
             }
             var dummyLink = document.createElement('a');

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -51,7 +51,7 @@ define(function(require) {
         onResourceClicked: function(event) {
             var data = $(event.currentTarget).data();
 
-            if ('document' !== data.type) {
+            if (data.type !== 'document') {
               window.top.open(data.href);
               return;
             }

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -52,7 +52,7 @@ define(function(require) {
             var data = $(event.currentTarget).data();
 
             if ('document' !== data.type) {
-              window.top.open($(event.currentTarget).data("href"));
+              window.top.open(data.href);
               return;
             }
             var dummyLink = document.createElement('a');

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -52,9 +52,9 @@ define(function(require) {
             var data = $(event.currentTarget).data();
 
             if (data.type !== 'document') {
-              window.top.open(data.href);
+                window.top.open(data.href);
             } else {
-              $('<a/>', { href: data.href, download: data.filename })[0].click();
+                $('<a/>', { href: data.href, download: data.filename })[0].click();
             }
         }
     });

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -53,16 +53,9 @@ define(function(require) {
 
             if (data.type !== 'document') {
               window.top.open(data.href);
-              return;
+            } else {
+              $('<a/>', { href: data.href, download: data.filename })[0].click();
             }
-            var dummyLink = document.createElement('a');
-            dummyLink.download = data.filename;
-            dummyLink.href = data.href;
-              
-            document.body.appendChild(dummyLink);
-            dummyLink.click();
-            document.body.removeChild(dummyLink);
-            delete dummyLink;
         }
     });
 

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -49,7 +49,20 @@ define(function(require) {
         },
 
         onResourceClicked: function(event) {
-            window.top.open($(event.currentTarget).data("href"));
+            var data = $(event.currentTarget).data();
+
+            if ('document' !== data.type) {
+              window.top.open($(event.currentTarget).data("href"), 'MyFile.jpg');
+              return;
+            }
+            var dummyLink = document.createElement('a');
+            dummyLink.download = data.filename;
+            dummyLink.href = data.href;
+              
+            document.body.appendChild(dummyLink);
+            dummyLink.click();
+            document.body.removeChild(dummyLink);
+            delete dummyLink;
         }
     });
 

--- a/properties.schema
+++ b/properties.schema
@@ -151,7 +151,8 @@
                         "required": false,
                         "title": "Filename",
                         "inputType": "Text",
-                        "translatable": true
+                        "translatable": true,
+                        "help":"This can be used to set the name of the file when downloaded by the user, if different from the source filename."
                       },
                       "description": {
                         "type": "string",

--- a/properties.schema
+++ b/properties.schema
@@ -166,7 +166,7 @@
                         "type": "string",
                         "required": true,
                         "title": "Link",
-                        "inputType": "Asset",
+                        "inputType": "Asset:other",
                         "validators": ["required"]
                       }
                     }

--- a/properties.schema
+++ b/properties.schema
@@ -133,22 +133,29 @@
                     "properties": {
                       "_type": {
                         "type": "string",
-                        "require": true,
+                        "required": true,
                         "title": "Type",
                         "inputType": { "type": "Select", "options": ["document", "media", "link"]},
                         "validators": ["required"]
                       },
                       "title": {
                         "type": "string",
-                        "require": true,
+                        "required": true,
                         "title": "Title",
                         "inputType": "Text",
                         "validators": ["required"],
                         "translatable": true
                       },
+                      "filename": {
+                        "type": "string",
+                        "required": false,
+                        "title": "Filename",
+                        "inputType": "Text",
+                        "translatable": true
+                      },
                       "description": {
                         "type": "string",
-                        "require": false,
+                        "required": false,
                         "title": "Description",
                         "inputType": "Text",
                         "validators": [],
@@ -156,7 +163,7 @@
                       },
                       "_link": {
                         "type": "string",
-                        "require": true,
+                        "required": true,
                         "title": "Link",
                         "inputType": "Asset",
                         "validators": ["required"]

--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -26,7 +26,7 @@
 	<div class="resources-item-container">
 	{{#each resources}}
 	<div class="resources-item drawer-item {{_type}}">
-		<button class="base resources-item-open drawer-item-open" data-href="{{_link}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
+		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
 			<div class="drawer-item-title">
 				<div class="drawer-item-title-inner h5">{{{title}}}</div>
 			</div>


### PR DESCRIPTION
See https://github.com/adaptlearning/adapt_framework/issues/1377

This change adds support for a new properties in resource items, which can be used to change the displayname of a document on download.

This feature should not break existing on future courses that do not define this attribute, and should fall back to the current behaviour.