### PR TITLE
stop PDFs from opening in same window as course in IE

### DIFF
--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -1,7 +1,6 @@
-define(function(require) {
-
-    var Backbone = require('backbone');
-    var Adapt = require('core/js/adapt');
+define([
+    'core/js/adapt'
+], function(Adapt) {
 
     var ResourcesView = Backbone.View.extend({
 
@@ -55,6 +54,7 @@ define(function(require) {
                 window.top.open(data.href);
                 return;
             }
+
             var dummyLink = document.createElement('a');
             // Internet Explorer has no support for the 'download' attribute
             if(Adapt.device.browser.toLowerCase() === "internet explorer") {

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -56,7 +56,12 @@ define(function(require) {
                 return;
             }
             var dummyLink = document.createElement('a');
-            dummyLink.download = data.filename;
+            // Internet Explorer has no support for the 'download' attribute
+            if(Adapt.device.browser.toLowerCase() === "internet explorer") {
+                dummyLink.target = "_blank";
+            } else {
+                dummyLink.download = data.filename;
+            }
             dummyLink.href = data.href;
 
             document.body.appendChild(dummyLink);


### PR DESCRIPTION
when the user has installed an ActiveX control (such as Acrobat Reader DC) that will render PDFs in the browser