### PR TITLE
#1643 - Individual resources can now be set to download or open in new window 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,60 @@
-# adapt-contrib-resources
-
-**Resources** is an *extension* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
-<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/resources01.gif" alt="Resources in action">
+# adapt-contrib-resources  
+    
+**Resources** is an *extension* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).  
+<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/resources01.gif" alt="Resources in action">      
 
 **Resources** provides a way to present extra materials to the learner that is outside of content flow. **Resources** takes advantage of the Drawer&mdash;a panel that slides out from the right-hand side of the page. It is always accessible to the learner through an icon in the navigation bar. **Resources** organises links to documents such as PDFs, links to media, and links to other web resources.
 
-[Visit the **Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about its functionality.
+[Visit the **Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about its functionality. 
 
 ## Installation
 
 As one of Adapt's *[core extensions](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#extensions),* **Resources** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Resources** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:  
 `adapt install adapt-contrib-resources`
 
-    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
-    `"adapt-contrib-resources": "*"`
-    Then running the command:
-    `adapt install`
-    (This second method will reinstall all plug-ins listed in *adapt.json*.)
+    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:  
+    `"adapt-contrib-resources": "*"`  
+    Then running the command:  
+    `adapt install`  
+    (This second method will reinstall all plug-ins listed in *adapt.json*.)  
 
-* If **Resources** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
+* If **Resources** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).  
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
-## Settings
-The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).
+## Settings  
+The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).  
 
-**_resources** (object): The Resources object that contains values for **title**, **description**, **_filterButtons**, **_filterAria**, and **_resourcesItems**.
+**_resources** (object): The Resources object that contains values for **title**, **description**, **_filterButtons**, **_filterAria**, and **_resourcesItems**.  
 
->**_isEnabled** (boolean): Turns **Resources** on and off. Acceptable values are `true` and `false`.
+>**_isEnabled** (boolean): Turns **Resources** on and off. Acceptable values are `true` and `false`. 
 
->**_forceDownload** (boolean): Forces a resource item to be downloaded when turned on. When off, it will open in a new window.
+>**title** (string): This text is displayed (along with the **description**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  
 
->**title** (string): This text is displayed (along with the **description**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.
-
->**description** (string): This text is displayed (along with the **title**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.
+>**description** (string): This text is displayed (along with the **title**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  
 
 >**_filterButtons** (object):  This attribute group maintains the labels for the four buttons that filter resources by type. It contains values for **all**, **document**, **media**, and **link**.
 
->>**all** (string): This text appears on the button that returns all **_resourcesItems**.
+>>**all** (string): This text appears on the button that returns all **_resourcesItems**.    
 
->>**document** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "document"`.
+>>**document** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "document"`.  
 
->>**media** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "media"`.
+>>**media** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "media"`.  
 
->>**link** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "link"`.
+>>**link** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "link"`.    
 
->**_filterAria** (object): This attribute group maintains the Aria labels for the four buttons that filter resources by type. It contains values for **allAria**, **documentAria**, **mediaAria**, and **linkAria**.
+>**_filterAria** (object): This attribute group maintains the Aria labels for the four buttons that filter resources by type. It contains values for **allAria**, **documentAria**, **mediaAria**, and **linkAria**.  
 
->>**allAria** (string): This text is associated with the button that returns all **_resourcesItems** and is read by assistive technologies.
+>>**allAria** (string): This text is associated with the button that returns all **_resourcesItems** and is read by assistive technologies.    
 
->>**documentAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "document"`and is read by assistive technologies.
+>>**documentAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "document"`and is read by assistive technologies.  
 
->>**mediaAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "media"`and is read by assistive technologies.
+>>**mediaAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "media"`and is read by assistive technologies.  
 
->>**linkAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "link"`and is read by assistive technologies.
+>>**linkAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "link"`and is read by assistive technologies.  
 
 >**itemAriaExternal** (string): This text is associated with each resource item. It renders as part of the aria label to tell screen readers that the content will open in an external link.
 
@@ -64,9 +62,9 @@ The attributes listed below are used in *course.json* to configure **Resources**
 
 >>**_type** (string):  This text is used to filter resources. If the resource is to be returned in a filtered group, this value must be one of the following: `document`, `media`, or `link`. (Note: There is no file type validation as part of **Resources**.)
 
->>**title** (string):  This text appears (along with **description**) as a label on the button that links to the item.
+>>**title** (string):  This text appears (along with **description**) as a label on the button that links to the item.  
 
->>**description** (string):  This optional text appears (along with **title**) as a label on the button that links to the item.
+>>**description** (string):  This optional text appears (along with **title**) as a label on the button that links to the item.    
 
 >>**filename** (string): This can be used to set the name of the file when downloaded by the user, if different from the source filename. (This feature is not supported on IE8-IE11, or Safari 10.)
 
@@ -75,13 +73,13 @@ The attributes listed below are used in *course.json* to configure **Resources**
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
-
-No known limitations.
+ 
+No known limitations.  
 
 ----------------------------
-**Version number:**  2.0.7   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
-**Framework versions:**  2.0
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)
-**Accessibility support:** WAI AA
-**RTL support:** yes
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge 12, IE 11, IE10, IE9, IE8, IE Mobile 11, Safari iOS 9+10, Safari OS X 9+10, Opera
+**Version number:**  2.0.7   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Framework versions:**  2.0     
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)    
+**Accessibility support:** WAI AA   
+**RTL support:** yes  
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge 12, IE 11, IE10, IE9, IE8, IE Mobile 11, Safari iOS 9+10, Safari OS X 9+10, Opera   

--- a/README.md
+++ b/README.md
@@ -1,60 +1,62 @@
-# adapt-contrib-resources  
-    
-**Resources** is an *extension* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).  
-<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/resources01.gif" alt="Resources in action">      
+# adapt-contrib-resources
+
+**Resources** is an *extension* bundled with the [Adapt framework](https://github.com/adaptlearning/adapt_framework).
+<img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/resources01.gif" alt="Resources in action">
 
 **Resources** provides a way to present extra materials to the learner that is outside of content flow. **Resources** takes advantage of the Drawer&mdash;a panel that slides out from the right-hand side of the page. It is always accessible to the learner through an icon in the navigation bar. **Resources** organises links to documents such as PDFs, links to media, and links to other web resources.
 
-[Visit the **Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about its functionality. 
+[Visit the **Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about its functionality.
 
 ## Installation
 
 As one of Adapt's *[core extensions](https://github.com/adaptlearning/adapt_framework/wiki/Core-Plug-ins-in-the-Adapt-Learning-Framework#extensions),* **Resources** is included with the [installation of the Adapt framework](https://github.com/adaptlearning/adapt_framework/wiki/Manual-installation-of-the-Adapt-framework#installation) and the [installation of the Adapt authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki/Installing-Adapt-Origin).
 
 * If **Resources** has been uninstalled from the Adapt framework, it may be reinstalled.
-With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:  
+With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run the following from the command line:
 `adapt install adapt-contrib-resources`
 
-    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:  
-    `"adapt-contrib-resources": "*"`  
-    Then running the command:  
-    `adapt install`  
-    (This second method will reinstall all plug-ins listed in *adapt.json*.)  
+    Alternatively, this component can also be installed by adding the following line of code to the *adapt.json* file:
+    `"adapt-contrib-resources": "*"`
+    Then running the command:
+    `adapt install`
+    (This second method will reinstall all plug-ins listed in *adapt.json*.)
 
-* If **Resources** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).  
+* If **Resources** has been uninstalled from the Adapt authoring tool, it may be reinstalled using the [Plug-in Manager](https://github.com/adaptlearning/adapt_authoring/wiki/Plugin-Manager).
 
 <div float align=right><a href="#top">Back to Top</a></div>
 
-## Settings  
-The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).  
+## Settings
+The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).
 
-**_resources** (object): The Resources object that contains values for **title**, **description**, **_filterButtons**, **_filterAria**, and **_resourcesItems**.  
+**_resources** (object): The Resources object that contains values for **title**, **description**, **_filterButtons**, **_filterAria**, and **_resourcesItems**.
 
->**_isEnabled** (boolean): Turns **Resources** on and off. Acceptable values are `true` and `false`. 
+>**_isEnabled** (boolean): Turns **Resources** on and off. Acceptable values are `true` and `false`.
 
->**title** (string): This text is displayed (along with the **description**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  
+>**_forceDownload** (boolean): Forces a resource item to be downloaded when turned on. When off, it will open in a new window.
 
->**description** (string): This text is displayed (along with the **title**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  
+>**title** (string): This text is displayed (along with the **description**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.
+
+>**description** (string): This text is displayed (along with the **title**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.
 
 >**_filterButtons** (object):  This attribute group maintains the labels for the four buttons that filter resources by type. It contains values for **all**, **document**, **media**, and **link**.
 
->>**all** (string): This text appears on the button that returns all **_resourcesItems**.    
+>>**all** (string): This text appears on the button that returns all **_resourcesItems**.
 
->>**document** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "document"`.  
+>>**document** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "document"`.
 
->>**media** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "media"`.  
+>>**media** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "media"`.
 
->>**link** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "link"`.    
+>>**link** (string): This text appears on the filter button that returns **_resourcesItems** with `"_type": "link"`.
 
->**_filterAria** (object): This attribute group maintains the Aria labels for the four buttons that filter resources by type. It contains values for **allAria**, **documentAria**, **mediaAria**, and **linkAria**.  
+>**_filterAria** (object): This attribute group maintains the Aria labels for the four buttons that filter resources by type. It contains values for **allAria**, **documentAria**, **mediaAria**, and **linkAria**.
 
->>**allAria** (string): This text is associated with the button that returns all **_resourcesItems** and is read by assistive technologies.    
+>>**allAria** (string): This text is associated with the button that returns all **_resourcesItems** and is read by assistive technologies.
 
->>**documentAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "document"`and is read by assistive technologies.  
+>>**documentAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "document"`and is read by assistive technologies.
 
->>**mediaAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "media"`and is read by assistive technologies.  
+>>**mediaAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "media"`and is read by assistive technologies.
 
->>**linkAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "link"`and is read by assistive technologies.  
+>>**linkAria** (string): This text is associated with the button that returns **_resourcesItems** with `"_type": "link"`and is read by assistive technologies.
 
 >**itemAriaExternal** (string): This text is associated with each resource item. It renders as part of the aria label to tell screen readers that the content will open in an external link.
 
@@ -62,9 +64,9 @@ The attributes listed below are used in *course.json* to configure **Resources**
 
 >>**_type** (string):  This text is used to filter resources. If the resource is to be returned in a filtered group, this value must be one of the following: `document`, `media`, or `link`. (Note: There is no file type validation as part of **Resources**.)
 
->>**title** (string):  This text appears (along with **description**) as a label on the button that links to the item.  
+>>**title** (string):  This text appears (along with **description**) as a label on the button that links to the item.
 
->>**description** (string):  This optional text appears (along with **title**) as a label on the button that links to the item.    
+>>**description** (string):  This optional text appears (along with **title**) as a label on the button that links to the item.
 
 >>**filename** (string): This can be used to set the name of the file when downloaded by the user, if different from the source filename. (This feature is not supported on IE8-IE11, or Safari 10.)
 
@@ -73,13 +75,13 @@ The attributes listed below are used in *course.json* to configure **Resources**
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Limitations
- 
-No known limitations.  
+
+No known limitations.
 
 ----------------------------
-**Version number:**  2.0.7   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
-**Framework versions:**  2.0     
-**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)    
-**Accessibility support:** WAI AA   
-**RTL support:** yes  
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge 12, IE 11, IE10, IE9, IE8, IE Mobile 11, Safari iOS 9+10, Safari OS X 9+10, Opera   
+**Version number:**  2.0.7   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a>
+**Framework versions:**  2.0
+**Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)
+**Accessibility support:** WAI AA
+**RTL support:** yes
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge 12, IE 11, IE10, IE9, IE8, IE Mobile 11, Safari iOS 9+10, Safari OS X 9+10, Opera

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ The attributes listed below are used in *course.json* to configure **Resources**
 
 >**_isEnabled** (boolean): Turns **Resources** on and off. Acceptable values are `true` and `false`. 
 
+>**_forceDownload** (boolean): Forces a resource item to be downloaded when active. Otherwise it will open in a new window. Acceptable values are `true` and `false`.
+
 >**title** (string): This text is displayed (along with the **description**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  
 
 >**description** (string): This text is displayed (along with the **title**) in the [Drawer](https://github.com/adaptlearning/adapt_framework/wiki/Core-modules#drawer) as part of a button that gives access to the resources.  

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-resources",
-  "version": "2.0.8",
+  "version": "2.0.7",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-resources",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-resources%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-resources",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "framework": "^2.0.0",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-resources",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-resources%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/example.json
+++ b/example.json
@@ -23,19 +23,22 @@
             "title":"Button idea",
             "description":"Click here to see a proposed button idea",
             "filename":"Buttons.pdf",
-            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf"
+            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf",
+            "_forceDownload": true
         },
         {
             "_type":"media",
             "title":"Adapt Learning YouTube Channel",
             "description":"Fancy catching up on some Adapt material",
-            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
+            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
+            "_forceDownload": false
         },
         {
             "_type":"link",
             "title":"Community Site",
             "description":"Click here to view our community site",
-            "_link":"https://community.adaptlearning.org"
-        }
+            "_link":"https://community.adaptlearning.org",
+            "_forceDownload": true
+        },
     ]
 }

--- a/example.json
+++ b/example.json
@@ -23,19 +23,22 @@
             "title":"Button idea",
             "description":"Click here to see a proposed button idea",
             "filename":"Buttons.pdf",
-            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf"
+            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf",
+            "_forceDownload": true
         },
         {
             "_type":"media",
             "title":"Adapt Learning YouTube Channel",
             "description":"Fancy catching up on some Adapt material",
-            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
+            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
+            "_forceDownload": false
         },
         {
             "_type":"link",
             "title":"Community Site",
             "description":"Click here to view our community site",
-            "_link":"https://community.adaptlearning.org"
+            "_link":"https://community.adaptlearning.org",
+            "_forceDownload": true
         }
     ]
 }

--- a/example.json
+++ b/example.json
@@ -38,7 +38,7 @@
             "title":"Community Site",
             "description":"Click here to view our community site",
             "_link":"https://community.adaptlearning.org",
-            "_forceDownload": true
+            "_forceDownload": false
         }
     ]
 }

--- a/example.json
+++ b/example.json
@@ -23,22 +23,19 @@
             "title":"Button idea",
             "description":"Click here to see a proposed button idea",
             "filename":"Buttons.pdf",
-            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf",
-            "_forceDownload": true
+            "_link":"course/en/pdf/adapt-framework-prototypes-buttons.pdf"
         },
         {
             "_type":"media",
             "title":"Adapt Learning YouTube Channel",
             "description":"Fancy catching up on some Adapt material",
-            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
-            "_forceDownload": false
+            "_link":"https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
         },
         {
             "_type":"link",
             "title":"Community Site",
             "description":"Click here to view our community site",
-            "_link":"https://community.adaptlearning.org",
-            "_forceDownload": true
-        },
+            "_link":"https://community.adaptlearning.org"
+        }
     ]
 }

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -50,7 +50,7 @@ define([
         onResourceClicked: function(event) {
             var data = $(event.currentTarget).data();
 
-            if (!data.forceDownload) {
+            if (!data.forcedownload) {
                 window.top.open(data.href);
                 return;
             }

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -50,7 +50,7 @@ define([
         onResourceClicked: function(event) {
             var data = $(event.currentTarget).data();
 
-            if (!data.forcedownload) {
+            if (!data.forceDownload) {
                 window.top.open(data.href);
                 return;
             }

--- a/js/adapt-contrib-resourcesView.js
+++ b/js/adapt-contrib-resourcesView.js
@@ -50,7 +50,7 @@ define([
         onResourceClicked: function(event) {
             var data = $(event.currentTarget).data();
 
-            if (data.type !== 'document') {
+            if (!data.forcedownload) {
                 window.top.open(data.href);
                 return;
             }

--- a/properties.schema
+++ b/properties.schema
@@ -148,6 +148,15 @@
                         "inputType": { "type": "Select", "options": ["document", "media", "link"]},
                         "validators": ["required"]
                       },
+                      "forceDownload": {
+                        "type": "boolean",
+                        "default": false,
+                        "title": "Force download",
+                        "inputType": "Checkbox",
+                        "validators": [],
+                        "translatable": true,
+                        "help": "Controls whether the Resource is opened in a new window or downloaded."
+                      },
                       "title": {
                         "type": "string",
                         "required": true,

--- a/properties.schema
+++ b/properties.schema
@@ -148,7 +148,7 @@
                         "inputType": { "type": "Select", "options": ["document", "media", "link"]},
                         "validators": ["required"]
                       },
-                      "forceDownload": {
+                      "_forceDownload": {
                         "type": "boolean",
                         "default": false,
                         "title": "Force download",

--- a/properties.schema
+++ b/properties.schema
@@ -148,7 +148,7 @@
                         "inputType": { "type": "Select", "options": ["document", "media", "link"]},
                         "validators": ["required"]
                       },
-                      "_forceDownload": {
+                      "forceDownload": {
                         "type": "boolean",
                         "default": false,
                         "title": "Force download",

--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -26,7 +26,7 @@
 	<div class="resources-item-container">
 	{{#each resources}}
 	<div class="resources-item drawer-item {{_type}}">
-		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" data-force-download="{{_forceDownload}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
+		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" data-forceDownload="{{forceDownload}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
 			<div class="drawer-item-title">
 				<div class="drawer-item-title-inner h5">{{{title}}}</div>
 			</div>

--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -26,7 +26,7 @@
 	<div class="resources-item-container">
 	{{#each resources}}
 	<div class="resources-item drawer-item {{_type}}">
-		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
+		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" data-forceDownload="{{forceDownload}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
 			<div class="drawer-item-title">
 				<div class="drawer-item-title-inner h5">{{{title}}}</div>
 			</div>

--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -26,7 +26,7 @@
 	<div class="resources-item-container">
 	{{#each resources}}
 	<div class="resources-item drawer-item {{_type}}">
-		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" data-forceDownload="{{forceDownload}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
+		<button class="base resources-item-open drawer-item-open" data-type="{{_type}}" data-filename="{{filename}}" data-href="{{_link}}" data-force-download="{{_forceDownload}}" tabindex="0" role="button" aria-label="{{lookup ../model._filterButtons _type}}. {{../model.itemAriaExternal}}. {{{title}}}. {{{description}}}">
 			<div class="drawer-item-title">
 				<div class="drawer-item-title-inner h5">{{{title}}}</div>
 			</div>


### PR DESCRIPTION
#1643 - Added a forceDownload property to resourceItems which defaults to false, all items now open in a new window by default. This setting can be changed to download for individual resource items. Slight tweak to the code executed on click of a resource, it now looks for the forcedownload option, rather than forcing documents to be downloaded. Version bump