### PR TITLE
Resolves #1917, corrects issue with drawer and multi-language courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The attributes listed below are used in *course.json* to configure **Resources**
 No known limitations.  
 
 ----------------------------
-**Version number:**  2.1.1   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
+**Version number:**  2.1.2   <a href="https://community.adaptlearning.org/" target="_blank"><img src="https://github.com/adaptlearning/documentation/blob/master/04_wiki_assets/plug-ins/images/adapt-logo-mrgn-lft.jpg" alt="adapt learning logo" align="right"></a> 
 **Framework versions:**  2.2+     
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)    
 **Accessibility support:** WAI AA   

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "adapt-contrib-resources",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "framework": ">=2.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-resources",
   "issues": "https://github.com/adaptlearning/adapt_framework/issues/new?title=contrib-resources%3A%20please%20enter%20a%20brief%20summary%20of%20the%20issue%20here&body=please%20provide%20a%20full%20description%20of%20the%20problem,%20including%20steps%20on%20how%20to%20replicate,%20what%20browser(s)/device(s)%20the%20problem%20occurs%20on%20and,%20where%20helpful,%20screenshots.",

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -39,8 +39,6 @@ define([
 
     }
 
-    Adapt.on('adapt:start', function() {
-        initResources();
-    });
+    Adapt.on('adapt:start', initResources());
 
 });

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -39,6 +39,6 @@ define([
 
     }
 
-    Adapt.on('adapt:start', initResources());
+    Adapt.on('adapt:start', initResources);
 
 });

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -39,9 +39,8 @@ define([
 
     }
 
-    Adapt.once('app:dataReady', function() {
+    Adapt.on('adapt:start', function() {
         initResources();
-        Adapt.on('app:languageChanged', initResources);
     });
 
 });


### PR DESCRIPTION
Since the core framework now takes care of managing the drawer removal it's no longer required to listen out for 'app:languageChanged'.