### PR TITLE
issue/109 Altering aria structure in drawer

### DIFF
--- a/js/ResourcesView.js
+++ b/js/ResourcesView.js
@@ -7,6 +7,12 @@ export default class ResourcesView extends Backbone.View {
     return 'resources';
   }
 
+  attributes() {
+    return {
+      role: 'group'
+    };
+  }
+
   initialize() {
     this.listenTo(Adapt, 'remove', this.remove);
     this.render();


### PR DESCRIPTION
[#109](https://github.com/adaptlearning/adapt-contrib-core/issues/109) The drawer__holder is taking on the role of 'list'. Recommending making the top level resource element a 'group'. https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#list