### PR TITLE
Fix: Labels for resources items are unnecessarily verbose (fixes #82)

### DIFF
--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -48,7 +48,7 @@
           download="{{filename}}"
           {{/resources_force_download}}
           target="_blank"
-          aria-label="{{{title}}}. {{lookup ../model._filterButtons _type}}.{{#if description}} {{{description}}}.{{/if}}">
+          aria-label="{{{title}}}.">
 
           {{#if title}}
           <div class="resources__item-title drawer__item-title">

--- a/templates/resources.hbs
+++ b/templates/resources.hbs
@@ -48,7 +48,7 @@
           download="{{filename}}"
           {{/resources_force_download}}
           target="_blank"
-          aria-label="{{{title}}}.">
+          aria-label="{{{title}}}">
 
           {{#if title}}
           <div class="resources__item-title drawer__item-title">


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)

[//]: # (Link the PR to the original issue)
fixes #82 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* Removes referenced tab title and description from aria-labels within each resource item. 

[//]: # (List appropriate steps for testing if needed)
### Testing
Test with this branch!

[//]: # (Mention any other dependencies)


