### PR TITLE
Fix: Remove unnecessary 'this' from currentTarget (fixes #91)

### DIFF
--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -46,7 +46,7 @@ export default function Resources (props) {
   const onFilterClicked = e => {
     if (e && e.preventDefault) e.preventDefault();
 
-    const $clickedButton = this.$(e.currentTarget);
+    const $clickedButton = $(e.currentTarget);
     const filter = $clickedButton.data('filter');
     const id = $clickedButton.attr('id');
 

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -56,7 +56,7 @@ export default function Resources (props) {
   };
 
   return (
-    <div className="component__inner resources__inner">
+    <div className="resources__inner">
 
       <templates.header {...props} />
 


### PR DESCRIPTION
[//]: # (Link the PR to the original issue)
Fixes #91 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* In onFilterClicked() in resources.jsx, removes 'this' from this.$(e.currentTarget).
* Removes `component__inner` class from `resources__inner`