### PR TITLE
Fix: Allow custom types (fixes #103)

### DIFF
--- a/example.json
+++ b/example.json
@@ -7,19 +7,28 @@
         "displayTitle": "",
         "body": "",
         "instruction": "",
-        "_filterButtons": {
-            "all": "All",
-            "document": "PDF",
-            "media": "Media",
-            "link": "Link"
-        },
-        "_comment": "_filterAria is to provide accessibility support for assistive technologies",
-        "_filterAria": {
-            "allAria": "View all resources",
-            "documentAria": "View document resources",
-            "mediaAria": "View media resources",
-            "linkAria": "View resource links"
-        },
+        "_resourcesTypes": [
+            {
+              "buttonText": "All",
+              "ariaLabel": "View all resources",
+              "_type": "all"
+            },
+            {
+              "buttonText": "Media",
+              "ariaLabel": "View media resources",
+              "_type": "media"
+            },
+            {
+              "buttonText": "Document",
+              "ariaLabel": "View document resources",
+              "_type": "document"
+            },
+            {
+              "buttonText": "Link",
+              "ariaLabel": "View resource links",
+              "_type": "link"
+            }
+        ],
         "_resourcesItems": [
             {
                 "_type": "document",

--- a/example.json
+++ b/example.json
@@ -53,15 +53,19 @@
                 "_type": "media",
                 "title": "Adapt Learning YouTube Channel",
                 "description": "Fancy catching up on some Adapt material",
-                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
-                "_forceDownload": false
+                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
             },
             {
                 "_type": "link",
                 "title": "Community Site",
                 "description": "Select here to view our community site",
-                "_link": "https://community.adaptlearning.org",
-                "_forceDownload": false
+                "_link": "https://community.adaptlearning.org"
+            },
+            {
+                "_type": "custom1",
+                "title": "GitHub",
+                "description": "Select here to view the Adapt respository on GitHub",
+                "_link": "https://github.com/adaptlearning"
             }
         ]
     }
@@ -82,15 +86,19 @@
                 "_type": "media",
                 "title": "Adapt Learning YouTube Channel",
                 "description": "Fancy catching up on some Adapt material",
-                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
-                "_forceDownload": false
+                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
             },
             {
                 "_type": "link",
                 "title": "Community Site",
                 "description": "Select here to view our community site",
-                "_link": "https://community.adaptlearning.org",
-                "_forceDownload": false
+                "_link": "https://community.adaptlearning.org"
+            },
+            {
+                "_type": "custom1",
+                "title": "GitHub",
+                "description": "Select here to view the Adapt respository on GitHub",
+                "_link": "https://github.com/adaptlearning"
             }
         ]
     }

--- a/example.json
+++ b/example.json
@@ -7,28 +7,19 @@
         "displayTitle": "",
         "body": "",
         "instruction": "",
-        "_resourcesTypes": [
-            {
-              "buttonText": "All",
-              "ariaLabel": "View all resources",
-              "_type": "all"
-            },
-            {
-              "buttonText": "Media",
-              "ariaLabel": "View media resources",
-              "_type": "media"
-            },
-            {
-              "buttonText": "Document",
-              "ariaLabel": "View document resources",
-              "_type": "document"
-            },
-            {
-              "buttonText": "Link",
-              "ariaLabel": "View resource links",
-              "_type": "link"
-            }
-        ],
+        "_filterButtons": {
+            "all": "All",
+            "document": "PDF",
+            "media": "Media",
+            "link": "Link"
+        },
+        "_comment": "_filterAria is to provide accessibility support for assistive technologies",
+        "_filterAria": {
+            "allAria": "View all resources",
+            "documentAria": "View document resources",
+            "mediaAria": "View media resources",
+            "linkAria": "View resource links"
+        },
         "_resourcesItems": [
             {
                 "_type": "document",

--- a/example.json
+++ b/example.json
@@ -11,14 +11,34 @@
             "all": "All",
             "document": "PDF",
             "media": "Media",
-            "link": "Link"
+            "link": "Link",
+            "custom1": "Custom category 1",
+            "custom2": "Custom category 2",
+            "custom3": "Custom category 3",
+            "custom4": "Custom category 4",
+            "custom5": "Custom category 5",
+            "custom6": "Custom category 6",
+            "custom7": "Custom category 7",
+            "custom8": "Custom category 8",
+            "custom9": "Custom category 9",
+            "custom10": "Custom category 10"
         },
         "_comment": "_filterAria is to provide accessibility support for assistive technologies",
         "_filterAria": {
             "allAria": "View all resources",
             "documentAria": "View document resources",
             "mediaAria": "View media resources",
-            "linkAria": "View resource links"
+            "linkAria": "View resource links",
+            "custom1Aria": "View custom category 1 links",
+            "custom2Aria": "View custom category 2 links",
+            "custom3Aria": "View custom category 3 links",
+            "custom4Aria": "View custom category 4 links",
+            "custom5Aria": "View custom category 5 links",
+            "custom6Aria": "View custom category 6 links",
+            "custom7Aria": "View custom category 7 links",
+            "custom8Aria": "View custom category 8 links",
+            "custom9Aria": "View custom category 9 links",
+            "custom10Aria": "View custom category 10 links"
         },
         "_resourcesItems": [
             {

--- a/js/ResourcesView.js
+++ b/js/ResourcesView.js
@@ -17,7 +17,8 @@ export default class ResourcesView extends Backbone.View {
   render() {
     const data = {
       model: this.model.toJSON(),
-      resources: this.model.get('_resources')
+      resources: this.model.get('_resources'),
+      resourceTypes: this.model.get('_resourceTypes')
     };
     ReactDOM.render(<templates.resources {...data} />, this.el);
 

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -54,7 +54,7 @@ class Resources extends Backbone.Controller {
   }
 
   setupTypes(model, resourcesData) {
-    const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type=> type !== 'all');
+    const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type => type !== 'all');
     const allTypes = [ 'all', ...configuredTypes ];
     model.set('_resourceTypes', allTypes);
   }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -47,7 +47,7 @@ class Resources extends Backbone.Controller {
       }
       model.set('_resources', resources);
 
-      this.setupTypes(model);
+      this.setupTypes(model, resourcesData);
 
       drawer.triggerCustomView(new ResourcesView({ model }).$el);
     });
@@ -55,14 +55,15 @@ class Resources extends Backbone.Controller {
 
   setupTypes(model, resourcesData) {
     const types = ['all']; // must contain 'all'
+    const filterButtons = resourcesData._filterButtons;
 
-    resourcesData._filterButtons.forEach((e, i) => {
-      const typeName = i;
+    for (const key in filterButtons) {
+      const typeName = key;
 
       if (typeName !== 'all') {
         types.push(typeName);
       }
-    });
+    };
 
     model.set('_resourceTypes', types);
   }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -47,11 +47,20 @@ class Resources extends Backbone.Controller {
       }
       model.set('_resources', resources);
 
-      const resourceTypes = ['all', 'document', 'media', 'link']; // must contain 'all'
-      model.set('_resourceTypes', resourceTypes);
+      this.setupTypes(model);
 
       drawer.triggerCustomView(new ResourcesView({ model }).$el);
     });
+  }
+
+  setupTypes(model) {
+    let types = ['all', 'document', 'media', 'link']; // must contain 'all'
+    const resourcesTypes = model.get('_resourcesTypes');
+    if (resourcesTypes) {
+      // Replace types with those defined in _resourcesTypes
+      // types = ['all', 'document', 'media', 'link'];
+    }
+    model.set('_resourceTypes', types);
   }
 }
 

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -54,12 +54,7 @@ class Resources extends Backbone.Controller {
   }
 
   setupTypes(model) {
-    let types = ['all', 'document', 'media', 'link']; // must contain 'all'
-    const resourcesTypes = model.get('_resourcesTypes');
-    if (resourcesTypes) {
-      // Replace types with those defined in _resourcesTypes
-      // types = ['all', 'document', 'media', 'link'];
-    }
+    const types = ['all', 'document', 'media', 'link', 'custom1', 'custom2', 'custom3', 'custom4', 'custom5']; // must contain 'all'
     model.set('_resourceTypes', types);
   }
 }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -54,7 +54,15 @@ class Resources extends Backbone.Controller {
   }
 
   setupTypes(model) {
-    const types = ['all', 'document', 'media', 'link', 'custom1', 'custom2', 'custom3', 'custom4', 'custom5']; // must contain 'all'
+    const defaultTypes = ['all', 'document', 'media', 'link']; // must contain 'all'
+
+    const customTypes = [];
+    for (let i = 1; i <= 10; i++) {
+      customTypes.push(`custom${i}`);
+    }
+
+    const types = defaultTypes.concat(customTypes);
+
     model.set('_resourceTypes', types);
   }
 }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -46,6 +46,10 @@ class Resources extends Backbone.Controller {
         resources = resources.filter(resource => resource._isGlobal !== false);
       }
       model.set('_resources', resources);
+
+      const resourceTypes = ['all', 'document', 'media', 'link']; // must contain 'all'
+      model.set('_resourceTypes', resourceTypes);
+
       drawer.triggerCustomView(new ResourcesView({ model }).$el);
     });
   }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -54,18 +54,9 @@ class Resources extends Backbone.Controller {
   }
 
   setupTypes(model, resourcesData) {
-    const types = ['all']; // must contain 'all'
-    const filterButtons = resourcesData._filterButtons;
-
-    for (const key in filterButtons) {
-      const typeName = key;
-
-      if (typeName !== 'all') {
-        types.push(typeName);
-      }
-    };
-
-    model.set('_resourceTypes', types);
+    const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type=> type !== 'all');
+    const allTypes = [ 'all', ...configuredTypes ];
+    model.set('_resourceTypes', allTypes);
   }
 
 }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -53,18 +53,20 @@ class Resources extends Backbone.Controller {
     });
   }
 
-  setupTypes(model) {
-    const defaultTypes = ['all', 'document', 'media', 'link']; // must contain 'all'
+  setupTypes(model, resourcesData) {
+    const types = ['all']; // must contain 'all'
 
-    const customTypes = [];
-    for (let i = 1; i <= 10; i++) {
-      customTypes.push(`custom${i}`);
-    }
+    resourcesData._filterButtons.forEach((e, i) => {
+      const typeName = i;
 
-    const types = defaultTypes.concat(customTypes);
+      if (typeName !== 'all') {
+        types.push(typeName);
+      }
+    });
 
     model.set('_resourceTypes', types);
   }
+
 }
 
 export default new Resources();

--- a/less/resources.less
+++ b/less/resources.less
@@ -3,6 +3,10 @@
     display: flex;
   }
 
+  &__filter.has-extra-types &__filter-inner {
+    flex-wrap: wrap;
+  } 
+
   &__filter-btn {
     flex-grow: 1;
   }

--- a/less/resources.less
+++ b/less/resources.less
@@ -9,6 +9,7 @@
 
   &__filter-btn {
     flex-grow: 1;
+    white-space: nowrap;
   }
 
   html:not(.ie) &__filter-btn {

--- a/properties.schema
+++ b/properties.schema
@@ -140,6 +140,86 @@
                       "inputType": "Text",
                       "validators": [],
                       "translatable": true
+                    },
+                    "custom1": {
+                      "type": "string",
+                      "default": "Custom category 1",
+                      "title": "Custom category 1",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom2": {
+                      "type": "string",
+                      "default": "Custom category 2",
+                      "title": "Custom category 2",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom3": {
+                      "type": "string",
+                      "default": "Custom category 3",
+                      "title": "Custom category 3",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom4": {
+                      "type": "string",
+                      "default": "Custom category 4",
+                      "title": "Custom category 4",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom5": {
+                      "type": "string",
+                      "default": "Custom category 5",
+                      "title": "Custom category 5",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom6": {
+                      "type": "string",
+                      "default": "Custom category 6",
+                      "title": "Custom category 6",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom7": {
+                      "type": "string",
+                      "default": "Custom category 7",
+                      "title": "Custom category 7",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom8": {
+                      "type": "string",
+                      "default": "Custom category 8",
+                      "title": "Custom category 8",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom9": {
+                      "type": "string",
+                      "default": "Custom category 9",
+                      "title": "Custom category 9",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom10": {
+                      "type": "string",
+                      "default": "Custom category 10",
+                      "title": "Custom category 10",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
                     }
                   }
                 },
@@ -175,6 +255,86 @@
                       "type": "string",
                       "default": "View resource links",
                       "title": "Links",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom1Aria": {
+                      "type": "string",
+                      "default": "View custom category 1 links",
+                      "title": "Custom category 1",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom2Aria": {
+                      "type": "string",
+                      "default": "View custom category 2 links",
+                      "title": "Custom category 2",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom3Aria": {
+                      "type": "string",
+                      "default": "View custom category 3 links",
+                      "title": "Custom category 3",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom4Aria": {
+                      "type": "string",
+                      "default": "View custom category 4 links",
+                      "title": "Custom category 4",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom5Aria": {
+                      "type": "string",
+                      "default": "View custom category 5 links",
+                      "title": "Custom category 5",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom6Aria": {
+                      "type": "string",
+                      "default": "View custom category 6 links",
+                      "title": "Custom category 6",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom7Aria": {
+                      "type": "string",
+                      "default": "View custom category 7 links",
+                      "title": "Custom category 7",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom8Aria": {
+                      "type": "string",
+                      "default": "View custom category 8 links",
+                      "title": "Custom category 1",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom9Aria": {
+                      "type": "string",
+                      "default": "View custom category 9 links",
+                      "title": "Custom category 9",
+                      "inputType": "Text",
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "custom10Aria": {
+                      "type": "string",
+                      "default": "View custom category 10 links",
+                      "title": "Custom category 10",
                       "inputType": "Text",
                       "validators": [],
                       "translatable": true

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -144,6 +144,86 @@
                   "_adapt": {
                     "translatable": true
                   }
+                },
+                "custom1": {
+                  "type": "string",
+                  "title": "Custom category 1",
+                  "default": "Custom category 1",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom2": {
+                  "type": "string",
+                  "title": "Custom category 2",
+                  "default": "Custom category 2",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom3": {
+                  "type": "string",
+                  "title": "Custom category 3",
+                  "default": "Custom category 3",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom4": {
+                  "type": "string",
+                  "title": "Custom category 4",
+                  "default": "Custom category 4",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom5": {
+                  "type": "string",
+                  "title": "Custom category 5",
+                  "default": "Custom category 5",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom6": {
+                  "type": "string",
+                  "title": "Custom category 6",
+                  "default": "Custom category 6",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom7": {
+                  "type": "string",
+                  "title": "Custom category 7",
+                  "default": "Custom category 7",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom8": {
+                  "type": "string",
+                  "title": "Custom category 8",
+                  "default": "Custom category 8",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom9": {
+                  "type": "string",
+                  "title": "Custom category 9",
+                  "default": "Custom category 9",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom10": {
+                  "type": "string",
+                  "title": "Custom category 10",
+                  "default": "Custom category 10",
+                  "_adapt": {
+                    "translatable": true
+                  }
                 }
               }
             },
@@ -180,6 +260,86 @@
                   "type": "string",
                   "title": "Links",
                   "default": "View resource links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom1Aria": {
+                  "type": "string",
+                  "title": "Custom category 1",
+                  "default": "View custom category 1 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom2Aria": {
+                  "type": "string",
+                  "title": "Custom category 2",
+                  "default": "View custom category 2 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom3Aria": {
+                  "type": "string",
+                  "title": "Custom category 3",
+                  "default": "View custom category 3 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom4Aria": {
+                  "type": "string",
+                  "title": "Custom category 4",
+                  "default": "View custom category 4 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom5Aria": {
+                  "type": "string",
+                  "title": "Custom category 5",
+                  "default": "View custom category 5 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom6Aria": {
+                  "type": "string",
+                  "title": "Custom category 6",
+                  "default": "View custom category 6 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom7Aria": {
+                  "type": "string",
+                  "title": "Custom category 7",
+                  "default": "View custom category 7 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom8Aria": {
+                  "type": "string",
+                  "title": "Custom category 8",
+                  "default": "View custom category 8 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom9Aria": {
+                  "type": "string",
+                  "title": "Custom category 9",
+                  "default": "View custom category 9 links",
+                  "_adapt": {
+                    "translatable": true
+                  }
+                },
+                "custom10Aria": {
+                  "type": "string",
+                  "title": "Custom category 10",
+                  "default": "View custom category 10 links",
                   "_adapt": {
                     "translatable": true
                   }

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -5,11 +5,11 @@ import { classes, templates } from 'core/js/reactHelpers';
 
 export default function Resources (props) {
   const {
-    resources
+    resources,
+    resourceTypes
   } = props;
 
   const _globals = Adapt.course.get('_globals');
-  const resourceTypes = ['all', 'document', 'media', 'link']; // must contain 'all'
 
   function resourcesHasMultipleTypes(resources) {
     if (resources.length === 1) return false;

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -61,10 +61,13 @@ export default function Resources (props) {
       <templates.header {...props.model} />
 
       {resourcesHasMultipleTypes(resources) &&
-      <div className={classes([
-        'resources__filter',
-        `has-${resourcesGetColumnCount(resources)}-columns`
-      ])}>
+      <div
+        className={classes([
+          'resources__filter',
+          `has-${resourcesGetColumnCount(resources)}-columns`,
+          (resourcesGetColumnCount(resources) > 4) && 'has-extra-types'
+        ])}
+      >
         <div className="resources__filter-inner" role="tablist">
 
           <div className="aria-label" aria-label={_globals._extensions._resources.resources} />


### PR DESCRIPTION
Fixes #103 

### Fix
* Adds the ability for custom types
* When using more than the default 4 types, a class of `has-extra-types` is added
* Schema updates

### Testing
1. Add custom categories according to _example.json_
2. Open the Resources drawer and behold the custom type buttons

### Potential additional enhancements
Suggested changes to the Vanilla theme (will require a new ticket / PR):

1. Reduce font size and padding when using extra custom types.
```
.resources__filter.has-extra-types {
  .resources__filter-btn {
    font-size: 0.75rem;
    padding: (@item-padding / 2) (@item-padding / 2);
  }
}
```
2. Remove style that removes the border from the last item.

### Screenshots
These screenshots show the maximum number of categories including the default ones.
<img src="https://user-images.githubusercontent.com/898168/234971523-7ddacc8d-092b-4e5b-853e-9eb6c624864d.jpg" width="350">

With Vanilla changes to font size and padding:
<img src="https://user-images.githubusercontent.com/898168/234971667-68f12130-de0e-4c9e-88b1-7e12ce269806.jpg" width="350">
