### PR TITLE
New: Add _enableFilters property (fixes #115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-re
 
 >**instruction** (string): The instruction text for the resources which displays at the top of the resources drawer.
 
->**\_enableFilterButtons** (boolean): Turns the filter buttons on and off. Acceptable values are `true` and `false`. Defaults to `true`. Note that the filter buttons will be automatically disabled if all `_resourcesItems` items have the same `_type` value.
+>**\_enableFilters** (boolean): Turns the filter buttons on and off. Acceptable values are `true` and `false`. Defaults to `true`. Note that the filter buttons will be automatically disabled if all `_resourcesItems` items have the same `_type` value.
 
 >**\_filterButtons** (object):  This attribute group maintains the labels for the four buttons that filter resources by type. It contains values for **all**, **document**, **media**, and **link**.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ With the [Adapt CLI](https://github.com/adaptlearning/adapt-cli) installed, run 
 <div float align=right><a href="#top">Back to Top</a></div>
 
 ## Settings
-The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).
+
+The attributes listed below are used in *course.json* to configure **Resources**, and are properly formatted as JSON in [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json). Some attributes can also be overridden for each content object in *contentObjects.json* (see [*example.json*](https://github.com/adaptlearning/adapt-contrib-resources/blob/master/example.json)).
+
+Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-resources/wiki) for more information about how they appear in the [authoring tool](https://github.com/adaptlearning/adapt_authoring/wiki).
 
 **\_resources** (object): The Resources object that contains values for **title**, **description**, **\_filterButtons**, **\_filterAria**, and **\_resourcesItems**.
 
@@ -43,6 +46,8 @@ The attributes listed below are used in *course.json* to configure **Resources**
 >**body** (string): The body text for the resources which displays at the top of the resources drawer.
 
 >**instruction** (string): The instruction text for the resources which displays at the top of the resources drawer.
+
+>**\_enableFilterButtons** (boolean): Turns the filter buttons on and off. Acceptable values are `true` and `false`. Defaults to `true`. Note that the filter buttons will be automatically disabled if all `_resourcesItems` items have the same `_type` value.
 
 >**\_filterButtons** (object):  This attribute group maintains the labels for the four buttons that filter resources by type. It contains values for **all**, **document**, **media**, and **link**.
 
@@ -91,4 +96,4 @@ No known limitations.
 **Author / maintainer:** Adapt Core Team with [contributors](https://github.com/adaptlearning/adapt-contrib-resources/graphs/contributors)<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 12+13 for macOS/iOS/iPadOS, Opera<br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera<br>

--- a/example.json
+++ b/example.json
@@ -7,6 +7,7 @@
         "displayTitle": "",
         "body": "",
         "instruction": "",
+        "_enableFilterButtons": true,
         "_filterButtons": {
             "all": "All",
             "document": "PDF",

--- a/example.json
+++ b/example.json
@@ -7,7 +7,7 @@
         "displayTitle": "",
         "body": "",
         "instruction": "",
-        "_enableFilterButtons": true,
+        "_enableFilters": true,
         "_filterButtons": {
             "all": "All",
             "document": "PDF",

--- a/js/ResourcesView.js
+++ b/js/ResourcesView.js
@@ -21,7 +21,8 @@ export default class ResourcesView extends Backbone.View {
       ...this,
       model: this.model.toJSON(),
       resources: this.model.get('_resources'),
-      resourceTypes: this.model.get('_resourceTypes')
+      resourceTypes: this.model.get('_resourceTypes'),
+      showFilters: this.model.get('_showFilters')
     };
     ReactDOM.render(<templates.resources {...data} />, this.el);
 

--- a/js/ResourcesView.js
+++ b/js/ResourcesView.js
@@ -22,8 +22,9 @@ export default class ResourcesView extends Backbone.View {
       model: this.model.toJSON(),
       resources: this.model.get('_resources'),
       resourceTypes: this.model.get('_resourceTypes'),
-      showFilters: this.model.get('_showFilters'),
-      filterColumnCount: this.model.get('_filterColumnCount')
+      _showFilters: this.model.get('_showFilters'),
+      _filterColumnCount: this.model.get('_filterColumnCount'),
+      _canDownload: this.model.get('_canDownload')
     };
     ReactDOM.render(<templates.resources {...data} />, this.el);
 

--- a/js/ResourcesView.js
+++ b/js/ResourcesView.js
@@ -22,7 +22,8 @@ export default class ResourcesView extends Backbone.View {
       model: this.model.toJSON(),
       resources: this.model.get('_resources'),
       resourceTypes: this.model.get('_resourceTypes'),
-      showFilters: this.model.get('_showFilters')
+      showFilters: this.model.get('_showFilters'),
+      filterColumnCount: this.model.get('_filterColumnCount')
     };
     ReactDOM.render(<templates.resources {...data} />, this.el);
 

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -19,8 +19,7 @@ class Resources extends Backbone.Controller {
       title: courseResources.title,
       description: courseResources.description,
       className: 'is-resources',
-      drawerOrder: courseResources._drawerOrder || 0,
-      enableFilters: courseResources._enableFilters || true
+      drawerOrder: courseResources._drawerOrder || 0
     };
 
     drawer.addItem(drawerObject, 'resources:showResources');

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -64,7 +64,7 @@ class Resources extends Backbone.Controller {
   setupFilters(model, resources) {
     const hasMultipleResources = resources.length > 1;
     const hasMultipleTypes = !resources.every(_.matcher({ _type: resources[0]._type }));
-    const enableFilters = model.get('_enableFilters') !== undefined ? model.get('_enableFilters') : true;
+    const enableFilters = model.get('_enableFilters') ?? true;
 
     const showFilters = hasMultipleResources && hasMultipleTypes && enableFilters;
     model.set('_showFilters', showFilters);

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -1,5 +1,6 @@
 import Adapt from 'core/js/adapt';
 import drawer from 'core/js/drawer';
+import device from 'core/js/device';
 import ResourcesView from './ResourcesView';
 
 class Resources extends Backbone.Controller {
@@ -50,6 +51,7 @@ class Resources extends Backbone.Controller {
 
       this.setupTypes(model, resourcesData);
       this.setupFilters(model, resources);
+      this.setupCanDownload(model);
 
       drawer.triggerCustomView(new ResourcesView({ model }).$el);
     });
@@ -74,6 +76,17 @@ class Resources extends Backbone.Controller {
 
     const filterColumnCount = _.uniq(_.pluck(resources, '_type')).length + 1;
     model.set('_filterColumnCount', filterColumnCount);
+  }
+
+  /**
+    * IE doesn't support the 'download' attribute
+    * https://github.com/adaptlearning/adapt_framework/issues/1559
+    * and iOS just opens links with that attribute in the same window
+    * https://github.com/adaptlearning/adapt_framework/issues/1852
+  */
+  setupCanDownload(model) {
+    const canEnableDownloads = device.browser !== 'internet explorer' && device.OS !== 'ios';
+    model.set('_canDownload', canEnableDownloads);
   }
 
 }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -57,8 +57,11 @@ class Resources extends Backbone.Controller {
 
   setupTypes(model, resourcesData) {
     const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type => type !== 'all');
-    const allTypes = [ 'all', ...configuredTypes ];
-    model.set('_resourceTypes', allTypes);
+    const typesWithItems = [...configuredTypes].filter(type => {
+      return resourcesData._resourcesItems.some(_.matcher({ _type: type }));
+    });
+
+    model.set('_resourceTypes', [ 'all', ...typesWithItems ]);
   }
 
   setupFilters(model, resources) {

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -19,7 +19,7 @@ class Resources extends Backbone.Controller {
       description: courseResources.description,
       className: 'is-resources',
       drawerOrder: courseResources._drawerOrder || 0,
-      enableFilterButtons: courseResources._enableFilterButtons || true
+      enableFilters: courseResources._enableFilters || true
     };
 
     drawer.addItem(drawerObject, 'resources:showResources');
@@ -64,8 +64,9 @@ class Resources extends Backbone.Controller {
   setupFilters(model, resources) {
     const hasMultipleResources = resources.length > 1;
     const hasMultipleTypes = !resources.every(_.matcher({ _type: resources[0]._type }));
+    const enableFilters = model.get('_enableFilters') !== undefined ? model.get('_enableFilters') : true;
 
-    const showFilters = hasMultipleResources && hasMultipleTypes;
+    const showFilters = hasMultipleResources && hasMultipleTypes && enableFilters;
     model.set('_showFilters', showFilters);
 
     const filterColumnCount = _.uniq(_.pluck(resources, '_type')).length + 1;

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -58,7 +58,7 @@ class Resources extends Backbone.Controller {
 
   setupTypes(model, resourcesData) {
     const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type => type !== 'all');
-    const typesWithItems = [...configuredTypes].filter(type => {
+    const typesWithItems = configuredTypes.filter(type => {
       return resourcesData._resourcesItems.some(_.matcher({ _type: type }));
     });
 

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -62,19 +62,13 @@ class Resources extends Backbone.Controller {
   }
 
   setupFilters(model, resources) {
-    let showFilters = true;
-    const filterColumnCount = _.uniq(_.pluck(resources, '_type')).length + 1;
+    const hasMultipleResources = resources.length > 1;
+    const hasMultipleTypes = !resources.every(_.matcher({ _type: resources[0]._type }));
 
-    if (resources.length < 2) {
-      showFilters = false;
-    }
-
-    // Check if all types are the same
-    if (resources.every(_.matcher({ _type: resources[0]._type }))) {
-      showFilters = false;
-    }
-
+    const showFilters = hasMultipleResources && hasMultipleTypes;
     model.set('_showFilters', showFilters);
+
+    const filterColumnCount = _.uniq(_.pluck(resources, '_type')).length + 1;
     model.set('_filterColumnCount', filterColumnCount);
   }
 

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -63,6 +63,7 @@ class Resources extends Backbone.Controller {
 
   setupFilters(model, resources) {
     let showFilters = true;
+    const filterColumnCount = _.uniq(_.pluck(resources, '_type')).length + 1;
 
     if (resources.length < 2) {
       showFilters = false;
@@ -74,6 +75,7 @@ class Resources extends Backbone.Controller {
     }
 
     model.set('_showFilters', showFilters);
+    model.set('_filterColumnCount', filterColumnCount);
   }
 
 }

--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -18,7 +18,8 @@ class Resources extends Backbone.Controller {
       title: courseResources.title,
       description: courseResources.description,
       className: 'is-resources',
-      drawerOrder: courseResources._drawerOrder || 0
+      drawerOrder: courseResources._drawerOrder || 0,
+      enableFilterButtons: courseResources._enableFilterButtons || true
     };
 
     drawer.addItem(drawerObject, 'resources:showResources');
@@ -48,6 +49,7 @@ class Resources extends Backbone.Controller {
       model.set('_resources', resources);
 
       this.setupTypes(model, resourcesData);
+      this.setupFilters(model, resources);
 
       drawer.triggerCustomView(new ResourcesView({ model }).$el);
     });
@@ -57,6 +59,21 @@ class Resources extends Backbone.Controller {
     const configuredTypes = Object.keys(resourcesData._filterButtons).filter(type => type !== 'all');
     const allTypes = [ 'all', ...configuredTypes ];
     model.set('_resourceTypes', allTypes);
+  }
+
+  setupFilters(model, resources) {
+    let showFilters = true;
+
+    if (resources.length < 2) {
+      showFilters = false;
+    }
+
+    // Check if all types are the same
+    if (resources.every(_.matcher({ _type: resources[0]._type }))) {
+      showFilters = false;
+    }
+
+    model.set('_showFilters', showFilters);
   }
 
 }

--- a/properties.schema
+++ b/properties.schema
@@ -105,7 +105,7 @@
                   "help": "The instruction text for the resources which displays at the top of the resources drawer.",
                   "translatable": true
                 },
-                "_enableFilterButtons": {
+                "_enableFilters": {
                   "type": "boolean",
                   "required":true,
                   "default": true,
@@ -437,7 +437,7 @@
                   "validators": [],
                   "help": "Controls whether the Resources extension is enabled or disabled."
                 },
-                "_enableFilterButtons": {
+                "_enableFilters": {
                   "type": "boolean",
                   "required":true,
                   "default": true,

--- a/properties.schema
+++ b/properties.schema
@@ -105,6 +105,15 @@
                   "help": "The instruction text for the resources which displays at the top of the resources drawer.",
                   "translatable": true
                 },
+                "_enableFilterButtons": {
+                  "type": "boolean",
+                  "required":true,
+                  "default": true,
+                  "title": "Enable filter buttons",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
+                },
                 "_filterButtons": {
                   "type": "object",
                   "title": "Filter Buttons",
@@ -427,6 +436,15 @@
                   "inputType": "Checkbox",
                   "validators": [],
                   "help": "Controls whether the Resources extension is enabled or disabled."
+                },
+                "_enableFilterButtons": {
+                  "type": "boolean",
+                  "required":true,
+                  "default": true,
+                  "title": "Enable filter buttons",
+                  "inputType": "Checkbox",
+                  "validators": [],
+                  "help": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
                 },
                 "_resourcesItems": {
                   "type": "array",

--- a/properties.schema
+++ b/properties.schema
@@ -437,15 +437,6 @@
                   "validators": [],
                   "help": "Controls whether the Resources extension is enabled or disabled."
                 },
-                "_enableFilters": {
-                  "type": "boolean",
-                  "required":true,
-                  "default": true,
-                  "title": "Enable filter buttons",
-                  "inputType": "Checkbox",
-                  "validators": [],
-                  "help": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
-                },
                 "_resourcesItems": {
                   "type": "array",
                   "required": false,

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -19,6 +19,12 @@
               "description": "Controls whether the Resources extension is enabled or disabled",
               "default": true
             },
+            "_enableFilterButtons": {
+              "type": "boolean",
+              "title": "Enable filter buttons",
+              "default": true,
+              "description": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
+            },
             "_resourcesItems": {
               "type": "array",
               "title": "Items",

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -19,7 +19,7 @@
               "description": "Controls whether the Resources extension is enabled or disabled",
               "default": true
             },
-            "_enableFilterButtons": {
+            "_enableFilters": {
               "type": "boolean",
               "title": "Enable filter buttons",
               "default": true,

--- a/schema/contentobject.schema.json
+++ b/schema/contentobject.schema.json
@@ -19,12 +19,6 @@
               "description": "Controls whether the Resources extension is enabled or disabled",
               "default": true
             },
-            "_enableFilters": {
-              "type": "boolean",
-              "title": "Enable filter buttons",
-              "default": true,
-              "description": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
-            },
             "_resourcesItems": {
               "type": "array",
               "title": "Items",

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -108,7 +108,7 @@
                 "translatable": true
               }
             },
-            "_enableFilterButtons": {
+            "_enableFilters": {
               "type": "boolean",
               "title": "Enable filter buttons",
               "default": true,

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -108,6 +108,12 @@
                 "translatable": true
               }
             },
+            "_enableFilterButtons": {
+              "type": "boolean",
+              "title": "Enable filter buttons",
+              "default": true,
+              "description": "Turns the filter buttons on and off. Note that the filter buttons will be automatically disabled if all resource items have the same Type value."
+            },
             "_filterButtons": {
               "type": "object",
               "title": "Filter buttons",

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -7,15 +7,11 @@ export default function Resources (props) {
   const {
     resources,
     resourceTypes,
-    showFilters
+    showFilters,
+    filterColumnCount
   } = props;
 
   const _globals = Adapt.course.get('_globals');
-
-  function resourcesGetColumnCount(resources) {
-    return _.uniq(_.pluck(resources, '_type')).length + 1; // add 1 for the 'All' button column
-  }
-
   const [selectedFilter, setSelectedFilter] = useState('all');
   const [selectedId, setSelectedId] = useState('resources__show-all');
   const [focusFlag, setFocusFlag] = useState(false);
@@ -57,8 +53,8 @@ export default function Resources (props) {
       <div
         className={classes([
           'resources__filter',
-          `has-${resourcesGetColumnCount(resources)}-columns`,
-          (resourcesGetColumnCount(resources) > 4) && 'has-extra-types'
+          `has-${filterColumnCount}-columns`,
+          (filterColumnCount > 4) && 'has-extra-types'
         ])}
       >
         <div className="resources__filter-inner" role="tablist">

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -6,17 +6,11 @@ import { classes, templates } from 'core/js/reactHelpers';
 export default function Resources (props) {
   const {
     resources,
-    resourceTypes
+    resourceTypes,
+    showFilters
   } = props;
 
   const _globals = Adapt.course.get('_globals');
-
-  function resourcesHasMultipleTypes(resources) {
-    if (resources.length < 2) return false;
-
-    const allSameType = resources.every(_.matcher({ _type: resources[0]._type }));
-    return !allSameType;
-  }
 
   function resourcesGetColumnCount(resources) {
     return _.uniq(_.pluck(resources, '_type')).length + 1; // add 1 for the 'All' button column
@@ -59,8 +53,7 @@ export default function Resources (props) {
     <div className="resources__inner">
 
       <templates.header {...props.model} />
-
-      {resourcesHasMultipleTypes(resources) &&
+      {showFilters &&
       <div
         className={classes([
           'resources__filter',

--- a/templates/resources.jsx
+++ b/templates/resources.jsx
@@ -7,8 +7,8 @@ export default function Resources (props) {
   const {
     resources,
     resourceTypes,
-    showFilters,
-    filterColumnCount
+    _showFilters,
+    _filterColumnCount
   } = props;
 
   const _globals = Adapt.course.get('_globals');
@@ -49,12 +49,12 @@ export default function Resources (props) {
     <div className="resources__inner">
 
       <templates.header {...props.model} />
-      {showFilters &&
+      {_showFilters &&
       <div
         className={classes([
           'resources__filter',
-          `has-${filterColumnCount}-columns`,
-          (filterColumnCount > 4) && 'has-extra-types'
+          `has-${_filterColumnCount}-columns`,
+          (_filterColumnCount > 4) && 'has-extra-types'
         ])}
       >
         <div className="resources__filter-inner" role="tablist">

--- a/templates/resourcesFilterButton.jsx
+++ b/templates/resourcesFilterButton.jsx
@@ -5,19 +5,12 @@ export default function ResourcesFilterButton (props) {
   const {
     model,
     onClick,
-    resources,
     selected,
     _filter
   } = props;
 
   const buttonText = model._filterButtons[_filter];
   const ariaLabel = model._filterAria[`${_filter}Aria`];
-
-  function resourcesHasType(resources, type) {
-    return resources.some(_.matcher({ _type: type }));
-  }
-
-  if (!resourcesHasType(resources, _filter) && _filter !== 'all') return null;
 
   return (
     <button

--- a/templates/resourcesItem.jsx
+++ b/templates/resourcesItem.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import device from 'core/js/device';
 import { classes } from 'core/js/reactHelpers';
 
 export default function ResourcesItem (props) {
   const {
     _forceDownload,
+    _canDownload,
     _isGlobal,
     _link,
     _type,
@@ -15,20 +15,6 @@ export default function ResourcesItem (props) {
     title,
     onResourceItemClicked
   } = props;
-
-  /**
-   * IE doesn't support the 'download' attribute
-   * https://github.com/adaptlearning/adapt_framework/issues/1559
-   * and iOS just opens links with that attribute in the same window
-   * https://github.com/adaptlearning/adapt_framework/issues/1852
-   */
-  function resourcesForceDownload(filename, _forceDownload) {
-    if (device.browser === 'internet explorer' || device.OS === 'ios') {
-      return false;
-    }
-
-    return (_forceDownload || filename);
-  }
 
   return (
     <div
@@ -43,7 +29,7 @@ export default function ResourcesItem (props) {
       <a href={_link} className="resources__item-btn drawer__item-btn"
         data-type={_type}
         data-index={_index}
-        download={resourcesForceDownload(filename, _forceDownload) && filename }
+        download={(_canDownload && _forceDownload) && filename }
         onClick={onResourceItemClicked}
         target="_blank"
         rel="noreferrer"


### PR DESCRIPTION
Fix #115 

### New
* Adds the new `_enableFilters` option to _course.json_ for hiding / showing filter buttons. Defaults to `true` for backwards compatibility. Filter buttons will also continue to be automatically hidden if all the item `_type` properties are the same.
* Update schemas, _example.json_ and _README.md_ with the new property

### Fix
* Move some logic from the JSX into the JS (e.g. filter button column count).
* Update _README.md_: Include a bit about overriding some settings in _contentObjects.json_ since it was not explicitly stated. Also update the supported browser list.

### Testing
In _course.json_ for the `_resources` object:

1. Test with `"_enableFilters": true`
2. Test with `"_enableFilters": false`
3. Test with no `"_enableFilters"` property
4. Test when all resource items have the same `_type` value