### PR TITLE
Fix: Replace deprecated drawer.triggerCustomView with drawer.openCustomView (fixes #117)

### DIFF
--- a/js/adapt-contrib-resources.js
+++ b/js/adapt-contrib-resources.js
@@ -49,7 +49,7 @@ class Resources extends Backbone.Controller {
 
       this.setupTypes(model, resourcesData);
 
-      drawer.triggerCustomView(new ResourcesView({ model }).$el);
+      drawer.openCustomView(new ResourcesView({ model }).$el);
     });
   }
 


### PR DESCRIPTION
Fixes #117

### Fix
* Replaces deprecated `drawer.triggerCustomView` with `drawer.openCustomView`