### PR TITLE
Fix: Add all custom categories as valid _type values (fix #120)

### DIFF
--- a/properties.schema
+++ b/properties.schema
@@ -363,7 +363,7 @@
                         "type": "string",
                         "required": true,
                         "title": "Type",
-                        "inputType": { "type": "Select", "options": ["document", "media", "link"]},
+                        "inputType": { "type": "Select", "options": ["document", "media", "link", "custom1", "custom2", "custom3", "custom4", "custom5", "custom6", "custom7", "custom8", "custom9", "custom10"]},
                         "validators": ["required"]
                       },
                       "_forceDownload": {

--- a/schema/course.schema.json
+++ b/schema/course.schema.json
@@ -364,7 +364,17 @@
                     "enum": [
                       "document",
                       "media",
-                      "link"
+                      "link",
+                      "custom1",
+                      "custom2",
+                      "custom3",
+                      "custom4",
+                      "custom5",
+                      "custom6",
+                      "custom7",
+                      "custom8",
+                      "custom9",
+                      "custom10"
                     ],
                     "_backboneForms": "Select"
                   },


### PR DESCRIPTION
Fixes #120 

### Fix
* Add all custom categories as valid `_type` values

### Testing
1. Add a resource item with one of the 10 custom types. For example:
```
{
  "_type": "custom1",
  "title": "Adapt Project Site",
  "description": "View the project's web site by clicking here.",
  "_link": "https://www.adaptlearning.org/"
},
```
2. Upload course to the AAT.