### PR TITLE
Chore: Add _isGlobal to example.json and README.md (fixes #128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-re
 
 >**itemAriaExternal** (string): This text is associated with each resource item. It renders as part of the aria label to tell screen readers that the content will open in an external link.
 
->**\_resourcesItems** (object):  This object stores properties for each resource item. Multiple resource items may be created. Each contains values for **\_type**, **title**, **description** (optional), **\_link**, **filename** and **\_forceDownload**.
+>**\_resourcesItems** (object):  This object stores properties for each resource item. Multiple resource items may be created. Each contains values for **\_type**, **title**, **description** (optional), **\_link**, **filename** and **\_forceDownload**. In *course.json*, **\_isGlobal** is also available.
 
 >>**\_type** (string):  This text is used to filter resources. If the resource is to be returned in a filtered group, this value must be one of the following: `document`, `media`, `link`, or one of the ten custom types (ex. `custom1`, `custom2`). (Note: There is no file type validation as part of **Resources**.)
 
@@ -84,6 +84,8 @@ Visit the [**Resources** wiki](https://github.com/adaptlearning/adapt-contrib-re
 >>**filename** (string): Allows the name of the downloaded file to be different to that of the source filename. Note that this feature only works in browsers that support the [`download` attribute](https://caniuse.com/#search=download) and is mainly intended for Adapt Authoring Tool users.
 
 >>**\_forceDownload** (boolean): Forces the resource to be downloaded rather than opened in a new window. Defaults to `false`. Note that this feature only works in browsers that support the [`download` attribute](https://caniuse.com/#search=download) and only with resources that are part of the course content or available from a [same-origin URL](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy)
+
+>>**\_isGlobal** (boolean): If `true`, the item will appear on every page including the menu. When `false`, the item only appears on the menu. Defaults to `true`. Only available in *course.json*.
 
 <div float align=right><a href="#top">Back to Top</a></div>
 

--- a/example.json
+++ b/example.json
@@ -48,25 +48,29 @@
                 "description": "Select here to see a proposed button idea",
                 "_link": "course/en/pdf/adapt-framework-prototypes-buttons.pdf",
                 "filename": "Buttons.pdf",
-                "_forceDownload": true
+                "_forceDownload": true,
+                "_isGlobal": true
             },
             {
                 "_type": "media",
                 "title": "Adapt Learning YouTube Channel",
                 "description": "Fancy catching up on some Adapt material",
-                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ"
+                "_link": "https://www.youtube.com/channel/UCW8SlSFuCc--B66Gf9fAEcQ",
+                "_isGlobal": true
             },
             {
                 "_type": "link",
                 "title": "Community Site",
                 "description": "Select here to view our community site",
-                "_link": "https://community.adaptlearning.org"
+                "_link": "https://community.adaptlearning.org",
+                "_isGlobal": true
             },
             {
                 "_type": "custom1",
                 "title": "GitHub",
                 "description": "Select here to view the Adapt respository on GitHub",
-                "_link": "https://github.com/adaptlearning"
+                "_link": "https://github.com/adaptlearning",
+                "_isGlobal": true
             }
         ]
     }


### PR DESCRIPTION
Fixes #128 

### Fix
* Adds `_isGlobal` to _example.json_ and _README.md_
