### PR TITLE
Fix: e2e test updated to not check for aria-expanded (fixes #137)

### DIFF
--- a/test/e2e/menuResources.cy.js
+++ b/test/e2e/menuResources.cy.js
@@ -42,11 +42,9 @@ describe('Resources - Menu', function () {
 
   it('should be able to close the drawer by clicking X', () => {
     cy.get('button.drawer__close-btn').click();
-    cy.get('.drawer').should('have.attr', 'aria-expanded', 'false');
   });
 
   it('should be able to close the drawer by hitting ESC', () => {
     cy.get('.drawer').type('{esc}');
-    cy.get('.drawer').should('have.attr', 'aria-expanded', 'false');
   });
 });

--- a/test/e2e/menuResources.cy.js
+++ b/test/e2e/menuResources.cy.js
@@ -42,9 +42,11 @@ describe('Resources - Menu', function () {
 
   it('should be able to close the drawer by clicking X', () => {
     cy.get('button.drawer__close-btn').click();
+    cy.get('.drawer').should('have.attr', 'aria-hidden', 'true');
   });
 
   it('should be able to close the drawer by hitting ESC', () => {
     cy.get('.drawer').type('{esc}');
+    cy.get('.drawer').should('have.attr', 'aria-hidden', 'true');
   });
 });

--- a/test/e2e/pageResources.cy.js
+++ b/test/e2e/pageResources.cy.js
@@ -67,7 +67,6 @@ describe('Resources - Pages', function () {
       openResourceDrawer(this.multiDrawer);
 
       cy.get('button.drawer__close-btn').click();
-      cy.get('.drawer').should('have.attr', 'aria-expanded', 'false');
     });
   });
 
@@ -78,7 +77,6 @@ describe('Resources - Pages', function () {
       openResourceDrawer(this.multiDrawer);
 
       cy.get('.drawer').type('{esc}');
-      cy.get('.drawer').should('have.attr', 'aria-expanded', 'false');
     });
   });
 });

--- a/test/e2e/pageResources.cy.js
+++ b/test/e2e/pageResources.cy.js
@@ -67,6 +67,7 @@ describe('Resources - Pages', function () {
       openResourceDrawer(this.multiDrawer);
 
       cy.get('button.drawer__close-btn').click();
+      cy.get('.drawer').should('have.attr', 'aria-hidden', 'true');
     });
   });
 
@@ -77,6 +78,7 @@ describe('Resources - Pages', function () {
       openResourceDrawer(this.multiDrawer);
 
       cy.get('.drawer').type('{esc}');
+      cy.get('.drawer').should('have.attr', 'aria-hidden', 'true');
     });
   });
 });


### PR DESCRIPTION
[//]: # (Please title your PR according to eslint commit conventions)
[//]: # (See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint#eslint-convention for details)
Removed the check for aria-expanded on both menuResources and pageResources due to recent change to core drawer (https://github.com/adaptlearning/adapt-contrib-core/pull/663)

[//]: # (Link the PR to the original issue)
#137 

[//]: # (Delete Fix, Update, New and/or Breaking sections as appropriate)
### Fix
* e2e test updated to not check for aria-expanded (fixes #137)

